### PR TITLE
refactor(scala): use Scala 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies._
 
-ThisBuild / scalaVersion     := "2.13.1"
+ThisBuild / scalaVersion     := "2.12.8"
 ThisBuild / version          := "0.1.0-SNAPSHOT"
 ThisBuild / organization     := "circeeg"
 ThisBuild / organizationName := "circeeg"
@@ -11,9 +11,6 @@ val enumeratumCirceVersion = "1.5.23"
 lazy val root = (project in file("."))
   .settings(
     name := "circe-examples",
-    scalacOptions ++= Seq(
-      "-Ymacro-annotations",
-    ),
     libraryDependencies ++=
       Seq(
         "io.circe" %% "circe-core",
@@ -27,3 +24,7 @@ lazy val root = (project in file("."))
         "com.beachape" %% "enumeratum-circe" % enumeratumCirceVersion
       ),
   )
+
+// Macro paradise
+resolvers += Resolver.sonatypeRepo("releases")
+addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,11 @@
 import Dependencies._
 
-ThisBuild / scalaVersion     := "2.12.8"
+ThisBuild / scalaVersion     := "2.11.8"
 ThisBuild / version          := "0.1.0-SNAPSHOT"
 ThisBuild / organization     := "circeeg"
 ThisBuild / organizationName := "circeeg"
 
-val circeVersion = "0.12.3"
+val circeVersion = "0.12.0-M3"
 val enumeratumCirceVersion = "1.5.23"
 
 lazy val root = (project in file("."))
@@ -16,10 +16,8 @@ lazy val root = (project in file("."))
         "io.circe" %% "circe-core",
         "io.circe" %% "circe-generic",
         "io.circe" %% "circe-parser",
+        "io.circe" %% "circe-generic-extras",
       ).map(_ % circeVersion) ++
-      Seq(
-        "io.circe" %% "circe-generic-extras" % "0.12.2",
-      ) ++
       Seq(
         "com.beachape" %% "enumeratum-circe" % enumeratumCirceVersion
       ),

--- a/src/main/scala/main/Main.scala
+++ b/src/main/scala/main/Main.scala
@@ -11,7 +11,7 @@ import java.time.{Duration, ZonedDateTime}
 import circeeg.util.{FooVal, BarVal, Other}
 import circeeg.util.{Filter, DwellTimeFilter}
 import circeeg.util.{AgeBand, Demo, Gender}
-import circeeg.util.conf._
+import circeeg.util.Conf.custom
 
 object Main extends App {
   val np = Printer.spaces2
@@ -35,14 +35,14 @@ object Main extends App {
     endTime = ZonedDateTime.parse("2020-01-01T23:59:59+08:00"),
     minDwell = Duration.ofHours(1),
     maxDwell = None,
-    recurrence = None,
+    recurrence = None
   )
 
   // dwellTimeFilter.asJson.spaces2 also works
-  pp("encodedDwellTimeFilterWithNull", np.print(dwellTimeFilter.asJson))
-  pp("encodedDwellTimeFilterWithoutNull", dnp.print(dwellTimeFilter.asJson))
-  pp("decodedDwellTimeFilterWithNull", decode[Filter](np.print(dwellTimeFilter.asJson)).right.get)
-  pp("decodedDwellTimeFilterWithoutNull", decode[Filter](dnp.print(dwellTimeFilter.asJson)).right.get)
+  pp("encodedDwellTimeFilterWithNull", np.pretty(dwellTimeFilter.asJson))
+  pp("encodedDwellTimeFilterWithoutNull", dnp.pretty(dwellTimeFilter.asJson))
+  pp("decodedDwellTimeFilterWithNull", decode[Filter](np.pretty(dwellTimeFilter.asJson)).right.get)
+  pp("decodedDwellTimeFilterWithoutNull", decode[Filter](dnp.pretty(dwellTimeFilter.asJson)).right.get)
 
   //
   // Demo
@@ -93,19 +93,19 @@ object Main extends App {
   // Demo
 
   val demo1 = Demo(ages = None, genders = None)
-  pp("encodedDemo1WithNull", np.print(demo1.asJson))
-  pp("encodedDemo1WithoutNull", dnp.print(demo1.asJson))
-  pp("decodedDemo1WithNull", decode[Demo](np.print(demo1.asJson)).right.get)
-  pp("decodedDemo1WithoutNull", decode[Demo](dnp.print(demo1.asJson)).right.get)
+  pp("encodedDemo1WithNull", np.pretty(demo1.asJson))
+  pp("encodedDemo1WithoutNull", dnp.pretty(demo1.asJson))
+  pp("decodedDemo1WithNull", decode[Demo](np.pretty(demo1.asJson)).right.get)
+  pp("decodedDemo1WithoutNull", decode[Demo](dnp.pretty(demo1.asJson)).right.get)
 
   val demo2 = Demo(
     ages = Some(Set(AgeBand.withName("40-44"), AgeBand.withName("45-49"))),
-    genders = Some(Set(Gender.withName("male"), Gender.withName("female"))),
+    genders = Some(Set(Gender.withName("male"), Gender.withName("female")))
   )
-  pp("encodedDemo2WithNull", np.print(demo2.asJson))
-  pp("encodedDemo2WithoutNull", dnp.print(demo2.asJson))
-  pp("decodedDemo2WithNull", decode[Demo](np.print(demo2.asJson)).right.get)
-  pp("decodedDemo2WithoutNull", decode[Demo](dnp.print(demo2.asJson)).right.get)
+  pp("encodedDemo2WithNull", np.pretty(demo2.asJson))
+  pp("encodedDemo2WithoutNull", dnp.pretty(demo2.asJson))
+  pp("decodedDemo2WithNull", decode[Demo](np.pretty(demo2.asJson)).right.get)
+  pp("decodedDemo2WithoutNull", decode[Demo](dnp.pretty(demo2.asJson)).right.get)
 
   //
   // Others

--- a/src/main/scala/main/Main.scala
+++ b/src/main/scala/main/Main.scala
@@ -1,10 +1,9 @@
 package circeeg.main
 
-import io.circe._
-import io.circe.generic.auto._
-import io.circe.generic.extras._
-import io.circe.parser._
-import io.circe.syntax._
+import io.circe.Json
+import io.circe.parser.decode
+// This is for .asJson, usually imported as io.circe.syntax._
+import io.circe.syntax.EncoderOps
 import io.circe.Printer
 import java.time.{Duration, ZonedDateTime}
 

--- a/src/main/scala/util/Conf.scala
+++ b/src/main/scala/util/Conf.scala
@@ -1,6 +1,6 @@
 package circeeg.util
 
-import io.circe.generic.extras._
+import io.circe.generic.extras.Configuration
 
 object Conf {
   // This makes all members to be snake_case

--- a/src/main/scala/util/Conf.scala
+++ b/src/main/scala/util/Conf.scala
@@ -2,9 +2,9 @@ package circeeg.util
 
 import io.circe.generic.extras._
 
-package object conf {
+object Conf {
   // This makes all members to be snake_case
-  implicit val config: Configuration = Configuration.default
+  implicit val custom: Configuration = Configuration.default
     .withSnakeCaseConstructorNames
     .withSnakeCaseMemberNames
 }

--- a/src/main/scala/util/Demo.scala
+++ b/src/main/scala/util/Demo.scala
@@ -1,6 +1,6 @@
 package circeeg.util
 
-import io.circe.generic.extras._
+import io.circe.generic.extras.ConfiguredJsonCodec
 import enumeratum._
 
 import circeeg.util.Conf.custom

--- a/src/main/scala/util/Demo.scala
+++ b/src/main/scala/util/Demo.scala
@@ -3,7 +3,7 @@ package circeeg.util
 import io.circe.generic.extras._
 import enumeratum._
 
-import circeeg.util.conf._
+import circeeg.util.Conf.custom
 
 // DO NOT USE @ConfiguredJsonCodec for any of the enums because it will override
 // the custom enum naming behavior
@@ -11,7 +11,7 @@ import circeeg.util.conf._
 @ConfiguredJsonCodec
 final case class Demo(
   ages: Option[Set[AgeBand]],
-  genders: Option[Set[Gender]],
+  genders: Option[Set[Gender]]
 )
 
 //

--- a/src/main/scala/util/Filter.scala
+++ b/src/main/scala/util/Filter.scala
@@ -1,7 +1,7 @@
 package circeeg.util
 
 import io.circe.generic.JsonCodec
-import io.circe.generic.extras._
+import io.circe.generic.extras.ConfiguredJsonCodec
 import java.time.{Duration, ZonedDateTime}
 
 import circeeg.util.Conf._

--- a/src/main/scala/util/Filter.scala
+++ b/src/main/scala/util/Filter.scala
@@ -1,9 +1,10 @@
 package circeeg.util
 
+import io.circe.generic.JsonCodec
 import io.circe.generic.extras._
 import java.time.{Duration, ZonedDateTime}
 
-import circeeg.util.conf._
+import circeeg.util.Conf._
 
 @ConfiguredJsonCodec
 sealed trait Filter
@@ -15,5 +16,9 @@ case class DwellTimeFilter(
   endTime: ZonedDateTime,
   minDwell: Duration,
   maxDwell: Option[Duration],
-  recurrence: Option[Int],
+  recurrence: Option[Int]
 ) extends Filter
+
+// Only for Scala 2.11 + circe 0.12.0-M3
+// https://github.com/circe/circe/issues/251
+object Filter

--- a/src/main/scala/util/Other.scala
+++ b/src/main/scala/util/Other.scala
@@ -2,7 +2,7 @@ package circeeg.util
 
 import io.circe.generic.extras._
 
-import circeeg.util.conf._
+import circeeg.util.Conf.custom
 
 @ConfiguredJsonCodec
 sealed trait Other
@@ -12,3 +12,7 @@ case class FooVal(valInt: Int, valDbl: Option[Double]) extends Other
 
 @ConfiguredJsonCodec
 case class BarVal(valVec: Vector[String]) extends Other
+
+// Only for Scala 2.11 + circe 0.12.0-M3
+// https://github.com/circe/circe/issues/251
+object Other

--- a/src/main/scala/util/Other.scala
+++ b/src/main/scala/util/Other.scala
@@ -1,6 +1,6 @@
 package circeeg.util
 
-import io.circe.generic.extras._
+import io.circe.generic.extras.ConfiguredJsonCodec
 
 import circeeg.util.Conf.custom
 


### PR DESCRIPTION
For Scala 2.11, 2.11.8 should be used because the patch versions of 2.11
has ordering issues for `circe`.

Note that 2.12 works just as fine too, just that all the `circe` related
versions must be updated to the latest. 2.12 should work just like 2.13,
except the way the macro paradise is enabled in `build.sbt` is
different.

Also 2.11 does not accept trailing commas, and `print` is not available
for `circe` `0.12.0-M3`.