### PR TITLE
feat(enum): add case where enum relation is inverted

### DIFF
--- a/src/main/scala/main/Main.scala
+++ b/src/main/scala/main/Main.scala
@@ -12,6 +12,8 @@ import circeeg.util.{Filter, DwellTimeFilter}
 import circeeg.util.{AgeBand, Demo, Gender}
 import circeeg.util.Conf.custom
 
+import circeeg.util.{Base, X, Y}
+
 object Main extends App {
   val np = Printer.spaces2
   val dnp = Printer.spaces2.copy(dropNullValues = true)
@@ -21,6 +23,27 @@ object Main extends App {
     val dashes = "-" * title.length
     println(s"\n$title\n$dashes\n$v\n")
   }
+
+  //
+  // Base
+  //
+
+  val x: Base = Base.X(1)
+  val y: Base = Base.Y(1)
+  val z: Base = Base.Z("abc")
+  val a: Base = Base.A(123, List(456, 789), "def")
+
+  pp("x-encode", np.pretty(x.asJson))
+  pp("x-decode", decode[Base](np.pretty(x.asJson)).right.get)
+
+  pp("y-encode", np.pretty(y.asJson))
+  pp("y-decode", decode[Base](np.pretty(y.asJson)).right.get)
+
+  pp("z-encode", np.pretty(z.asJson))
+  pp("z-decode", decode[Base](np.pretty(z.asJson)).right.get)
+
+  pp("a-encode", np.pretty(a.asJson))
+  pp("a-decode", decode[Base](np.pretty(a.asJson)).right.get)
 
   //
   // Filter

--- a/src/main/scala/util/Base.scala
+++ b/src/main/scala/util/Base.scala
@@ -1,0 +1,85 @@
+package circeeg.util
+
+import cats.syntax.either._
+import io.circe.{Decoder, Encoder, HCursor, Json}
+import io.circe.generic.extras.ConfiguredJsonCodec
+import io.circe.syntax._
+
+import circeeg.util.Conf._
+
+@ConfiguredJsonCodec
+sealed trait Base
+
+object Base {
+  // To get all the function result mapping with different arities
+  import circeeg.util.Func._
+
+  // The case class (enum component) names below do not actually have to
+  // be exactly the same as the ones in Xyz.scala.
+  // They are named the same to easily correlate the two
+  // The case class name here however DO determine the automatic inferred
+  // JSON key name to use when serde-ing.
+
+  //
+  // X section
+  //
+
+  final case class X(v: circeeg.util.X) extends Base
+  object X {
+    // circeeg.util.X.apply _ means it literally takes on the method circeeg.util.X.apply
+    // and then we map over the result type O1 to O2
+    // This replaces the need to know: def apply(v: Int) = new X(circeeg.util.X(v))
+    def apply = (circeeg.util.X.apply _).mapResult(new X(_))
+  }
+
+  implicit val encodeX: Encoder[X] = new Encoder[X] {
+    final def apply(v: X) = v.v.asJson
+  }
+
+  implicit val decodeX: Decoder[X] = new Decoder[X] {
+    final def apply(c: HCursor) = for { v <- c.as[circeeg.util.X] } yield { new X(v) }
+  }
+
+  //
+  // End of X section (the above is all you need to make a macro)
+  //
+
+  final case class Y(v: circeeg.util.Y) extends Base
+  object Y {
+    def apply = (circeeg.util.Y.apply _).mapResult(new Y(_))
+  }
+
+  implicit val encodeY: Encoder[Y] = new Encoder[Y] {
+    final def apply(v: Y) = v.v.asJson
+  }
+
+  implicit val decodeY: Decoder[Y] = new Decoder[Y] {
+    final def apply(c: HCursor) = for { v <- c.as[circeeg.util.Y] } yield { new Y(v) }
+  }
+
+  final case class Z(v: circeeg.util.Z) extends Base
+  object Z {
+    def apply = (circeeg.util.Z.apply _).mapResult(new Z(_))
+  }
+
+  implicit val encodeZ: Encoder[Z] = new Encoder[Z] {
+    final def apply(v: Z) = v.v.asJson
+  }
+
+  implicit val decodeZ: Decoder[Z] = new Decoder[Z] {
+    final def apply(c: HCursor) = for { v <- c.as[circeeg.util.Z] } yield { new Z(v) }
+  }
+
+  // A uses arity-3
+
+  final case class A(v: circeeg.util.A) extends Base
+  object A { def apply = (circeeg.util.A.apply _).mapResult(new A(_)) }
+
+  implicit val encodeA: Encoder[A] = new Encoder[A] {
+    final def apply(v: A) = v.v.asJson
+  }
+
+  implicit val decodeB: Decoder[A] = new Decoder[A] {
+    final def apply(c: HCursor) = for { v <- c.as[circeeg.util.A] } yield { new A(v) }
+  }
+}

--- a/src/main/scala/util/Func.scala
+++ b/src/main/scala/util/Func.scala
@@ -1,0 +1,15 @@
+package circeeg.util
+
+object Func {
+  implicit class Func1Extra[I1, O1, O2](f: I1 => O1) {
+    def mapResult(g: O1 => O2): I1 => O2 = (i1: I1) => g(f(i1))
+  }
+
+  implicit class Func2Extra[I1, I2, O1, O2](f: (I1, I2) => O1) {
+    def mapResult(g: O1 => O2): (I1, I2) => O2 = (i1: I1, i2: I2) => g(f(i1, i2))
+  }
+
+  implicit class Func3Extra[I1, I2, I3, O1, O2](f: (I1, I2, I3) => O1) {
+    def mapResult(g: O1 => O2): (I1, I2, I3) => O2 = (i1: I1, i2: I2, i3: I3) => g(f(i1, i2, i3))
+  }
+}

--- a/src/main/scala/util/Xyz.scala
+++ b/src/main/scala/util/Xyz.scala
@@ -1,0 +1,32 @@
+package circeeg.util
+
+import io.circe.generic.extras.ConfiguredJsonCodec
+
+import circeeg.util.Conf._
+
+// The traits here are just to show that for some reason if you need to the
+// various enum components extend some traits, as long as the trait are just for
+// methods, it has no impact on the serialization hierarchy and neither do they
+// need to be circe annotated
+
+trait Useless
+trait UselessToo extends Useless
+
+// The following case classes totally do not need the above traits and do not
+// need to derive from any base traits
+// This flips the usual sealed trait which requires the base sealed trait
+// (enum base), and the enum components to be located in the same file
+// The enum base is actually in Base.scala instead, similar to how Rust enum
+// works
+
+@ConfiguredJsonCodec
+case class X(v: Int) extends UselessToo
+
+@ConfiguredJsonCodec
+case class Y(v: Int) extends Useless
+
+@ConfiguredJsonCodec
+case class Z(v: String) extends UselessToo
+
+@ConfiguredJsonCodec
+case class A(x: Int, y: List[Int], z: String) extends UselessToo


### PR DESCRIPTION
Add a different take on how the enum set-up can be done.

The usual enum is done via `sealed trait` acting as the enum base, but
this has severe limitation on the flexibility of the enum.

Rust can have completely unrelated sets of structs, before gathering
them in a enum base in a completely separate file, and achieve
auto-inferencing on how the serde is done.

Scala cannot easily do this because the enum relation is simulated by
inheritance, which causes an inverted relationship. This inverted
relationship makes it impossible to macro annotate the enum base at
times.