### PR TITLE
feat(circe): add forwarding macro annotation

### DIFF
--- a/extras/CirceForward.scala
+++ b/extras/CirceForward.scala
@@ -1,0 +1,51 @@
+package circeeg.extras
+
+import scala.annotation.StaticAnnotation
+import scala.annotation.compileTimeOnly
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox
+
+class CirceForward extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro CirceForwardMacro.impl
+}
+
+private class CirceForwardMacro(val c: whitebox.Context) {
+  import c.universe._
+
+  def impl(annottees: Tree*): Tree = {
+    annottees match {
+      case (clsDef @ q"case class $className(..$fields) extends { ..$earlydefns } with ..$parents { $self => ..$stats }") :: _ if fields.length == 1 => {
+        val classTypeName = className
+        val classTermName = classTypeName.toTermName
+        val classTypeStr = classTypeName.decodedName.toString
+
+        val encoderTermName = TermName("__encode" + classTypeStr)
+        val decoderTermName = TermName("__decode" + classTypeStr)
+
+        val field = fields(0)
+        val fieldName = field.name
+        val fieldTypeSelect = field.tpt
+
+        val q"$objTerm" = q"""
+          object $classTermName {
+            import cats.syntax.either._
+            import io.circe.syntax._
+
+            implicit val $encoderTermName: io.circe.Encoder[$classTypeName] = new io.circe.Encoder[$classTypeName] {
+              final def apply(v: $classTypeName) = v.$fieldName.asJson
+            }
+
+            implicit val $decoderTermName: io.circe.Decoder[$classTypeName] = new io.circe.Decoder[$classTypeName] {
+              final def apply(c: io.circe.HCursor) = for { v <- c.as[$fieldTypeSelect] } yield { new $classTypeName(v) }
+            }
+          }
+          """
+
+        q"$clsDef; $objTerm"
+      }
+      case _ => c.abort(
+        c.enclosingPosition,
+        "Invalid annotation target: must be a case class that contain only a single param value for forwarding")
+    }
+  }
+}

--- a/main/Main.scala
+++ b/main/Main.scala
@@ -13,6 +13,7 @@ import circeeg.util.{FooVal, BarVal, Other}
 import circeeg.util.{Filter, DwellTimeFilter}
 import circeeg.util.{AgeBand, Demo, Gender}
 import circeeg.util.Conf.custom
+import circeeg.util.ExprEnum
 import circeeg.util.NoneDefault._
 import circeeg.util.Sorl
 
@@ -24,6 +25,28 @@ object Main extends App {
   def pp[T](title: String, v: T) = {
     val dashes = "-" * title.length
     println(s"\n$title\n$dashes\n$v\n")
+  }
+
+  //
+  // Expr
+  //
+
+  {
+    import ExprEnum._
+
+    val expr1: ExprEnum = Lit(111)
+    val exprEncoded1 = expr1.asJson.noSpaces
+    pp("Expr encoded 1", exprEncoded1)
+    val exprDecoded1 = decode[ExprEnum](exprEncoded1).right.get
+    pp("Expr decoded 1", exprDecoded1)
+    pp("Expr eval 1", exprDecoded1.eval)
+
+    val expr2: ExprEnum = Add(Seq(Lit(111), Add(Seq(Lit(111), Lit(222)))))
+    val exprEncoded2 = expr2.asJson.noSpaces
+    pp("Expr encoded 2", exprEncoded2)
+    val exprDecoded2 = decode[ExprEnum](exprEncoded2).right.get
+    pp("Expr decoded 2", exprDecoded2)
+    pp("Expr eval 2", exprDecoded2.eval)
   }
 
   //

--- a/util/Base.scala
+++ b/util/Base.scala
@@ -3,7 +3,6 @@ package circeeg.util
 import cats.data.NonEmptyList
 import cats.syntax.either._
 import io.circe.generic.extras.ConfiguredJsonCodec
-import io.circe.syntax.EncoderOps  // .asJson needs this
 
 import circeeg.extras.{CirceEnumVariant, delegate}
 import circeeg.util.Conf.custom

--- a/util/Expr.scala
+++ b/util/Expr.scala
@@ -1,0 +1,36 @@
+package circeeg.util
+
+import io.circe.generic.extras.ConfiguredJsonCodec
+
+import circeeg.extras.{CirceForward, CirceEnumVariant, delegate}
+import circeeg.util.Conf.custom
+
+trait Expr {
+  def eval: Int
+}
+
+object Expr {
+  @CirceForward
+  case class Lit(v: Int) extends Expr {
+    def eval: Int = v
+  }
+
+  @CirceForward
+  case class Add(v: Seq[ExprEnum]) extends Expr {
+    def eval: Int = v.map(_.eval).sum
+  }
+}
+
+@ConfiguredJsonCodec
+sealed trait ExprEnum extends Expr {
+  val v: Expr
+  def eval: Int = v.eval
+}
+
+object ExprEnum {
+  @CirceEnumVariant
+  final case class Lit(v: Expr.Lit) extends ExprEnum
+
+  @CirceEnumVariant
+  final case class Add(v: Expr.Add) extends ExprEnum
+}

--- a/util/Filter.scala
+++ b/util/Filter.scala
@@ -4,7 +4,7 @@ import io.circe.generic.JsonCodec
 import io.circe.generic.extras.ConfiguredJsonCodec
 import java.time.{Duration, ZonedDateTime}
 
-import circeeg.util.Conf._
+import circeeg.util.Conf.custom
 
 @ConfiguredJsonCodec
 sealed trait Filter

--- a/util/SingleOrList.scala
+++ b/util/SingleOrList.scala
@@ -1,12 +1,14 @@
 package circeeg.util
 
 import io.circe.{Decoder, Encoder, HCursor, Json}
-import io.circe.syntax.EncoderOps
 import scala.util.{Left, Right}
 
 case class Sorl[T](val toList: List[T])
 
 object Sorl {
+  import cats.syntax.either._
+  import io.circe.syntax._
+
   final def apply[T](vs: T*): Sorl[T] = Sorl[T](List(vs: _*))
 
   implicit def sorlEncoder[T: Encoder]: Encoder[Sorl[T]] = new Encoder[Sorl[T]] {


### PR DESCRIPTION
Also clean up and generalize the previous `CirceEnumVariant` to work on
all other modifiers to `class` that do not matter to how macro works.