### PR TITLE
feat(circe): improve the enum variant macro

### DIFF
--- a/util/Base.scala
+++ b/util/Base.scala
@@ -61,14 +61,14 @@ object B2 {
 }
 
 object Base {
-  @CirceEnumVariant(case_class_fwd = false)
+  @CirceEnumVariant
   final case class B(v: String) extends Base {
     def foo(): String = "abc"
     def foo(x: Int): Int = id + 1
     def id: Int = 777
   }
 
-  @CirceEnumVariant(case_class_fwd = false)
+  @CirceEnumVariant
   final case class C(v: NonEmptyList[Int]) extends Base {
     def foo(): String = "NonEmptyList"
     def foo(x: Int): Int = id + 1

--- a/util/Expr2.scala
+++ b/util/Expr2.scala
@@ -9,10 +9,10 @@ import circeeg.util.Conf.custom
 sealed trait Expr2 extends Expr2Impl
 
 object Expr2 {
-  @CirceEnumVariant(case_class_fwd = false)
+  @CirceEnumVariant
   case class Lit(v: Int) extends LitImpl(v) with Expr2
 
-  @CirceEnumVariant(case_class_fwd = false)
+  @CirceEnumVariant
   case class Add(v: Seq[Expr2]) extends AddImpl(v) with Expr2
 
   // Cannot forward since two params


### PR DESCRIPTION
Fix by putting always putting fully qualiified inner companion type
rather than using a possible relative qualified one.

Auto deduce fully whether the single param is a case class or not. If
case class, it automatically creates the `apply` method for forwarding
into the inner case class. Otherwise, it does not create.

This eliminates the need to manually specify to include or not.