### PR TITLE
feat(scala): put version to 2.12.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ val circeVersion = "0.12.0-M3"
 val enumeratumCirceVersion = "1.5.23"
 
 val commonSettings = Seq(
-  scalaVersion := "2.11.8",
+  scalaVersion := "2.12.8",
   version := "0.1.0-SNAPSHOT",
   organization := "circeeg",
   organizationName := "circeeg",


### PR DESCRIPTION
This conveniently allows VSCode metals to auto infer for the macro
annotations, which is extremely useful.

2.12 so far works the same as 2.11, with the exception of tpe bugs for
very hard to use `delegate`.