### PR TITLE
feat(scalafix): add plugin

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,3 @@
+rules = [
+  RemoveUnused
+]

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,3 +1,11 @@
 rules = [
-  RemoveUnused
+  RemoveUnused,
+  SortImports
+]
+
+SortImports.blocks = [
+  "java.",
+  "scala.",
+  "*",
+  "circeeg."
 ]

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,12 @@
 import Dependencies._
 
+// scalafix has bug when RemoveUnused and SortImports are used together
+// Need to specifically do RemoveUnused in order to fix things
+// https://gitter.im/scalacenter/scalafix?at=5e8aa6655d148a0460e8fe64
+// We use aliases to mask the issue
+addCommandAlias("fix", "compile:scalafix; test:scalafix; compile:scalafix RemoveUnused; test:scalafix RemoveUnused")
+addCommandAlias("check", "compile:scalafix --check; test:scalafix --check")
+
 val circeVersion = "0.12.0-M3"
 val enumeratumCirceVersion = "1.5.23"
 val silencerVersion = "1.6.0"
@@ -24,7 +31,9 @@ val commonSettings = Seq(
   scalacOptions ++= Seq(
     "-feature",
     "-deprecation",
-    "-Ywarn-unused",
+    // Cannot use "-Ywarn-unused" because of stupid bugs like
+    // https://github.com/scala/bug/issues/11918
+    "-Ywarn-unused:-patvars,_",
     "-Yrangepos"
   ),
   libraryDependencies ++=
@@ -36,11 +45,6 @@ val commonSettings = Seq(
     ).map(_ % circeVersion) ++
     Seq(
       "com.beachape" %% "enumeratum-circe" % enumeratumCirceVersion,
-    ) ++
-    Seq(
-      // Scalafix warning silencer (only required for < Scala 2.13)
-      compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),
-      "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.full
     )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ import Dependencies._
 
 val circeVersion = "0.12.0-M3"
 val enumeratumCirceVersion = "1.5.23"
+val silencerVersion = "1.6.0"
 
 inThisBuild(
   Seq(
@@ -32,6 +33,11 @@ val commonSettings = Seq(
     ).map(_ % circeVersion) ++
     Seq(
       "com.beachape" %% "enumeratum-circe" % enumeratumCirceVersion,
+    ) ++
+    Seq(
+      // Scalafix warning silencer (only required for < Scala 2.13)
+      compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),
+      "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.full
     )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,10 @@ inThisBuild(
   Seq(
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision,
-    scalafixDependencies += "com.nequissimus" %% "sort-imports" % "0.3.2"
+    scalafixDependencies += "com.nequissimus" %% "sort-imports" % "0.3.2",
+
+    resolvers += Resolver.sonatypeRepo("releases"),
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,14 @@ import Dependencies._
 val circeVersion = "0.12.0-M3"
 val enumeratumCirceVersion = "1.5.23"
 
+inThisBuild(
+  Seq(
+    semanticdbEnabled := true,
+    semanticdbVersion := scalafixSemanticdb.revision,
+    scalafixDependencies += "com.nequissimus" %% "sort-imports" % "0.3.2"
+  )
+)
+
 // The set-up no longer supports for 2.11
 val commonSettings = Seq(
   scalaVersion := "2.12.8",
@@ -32,12 +40,16 @@ lazy val extras = (project in file("extras"))
     commonSettings
   )
 
-lazy val util = (project in file("util")).dependsOn(extras)
+lazy val util = (project in file("util"))
+  .aggregate(extras)
+  .dependsOn(extras)
   .settings(
     commonSettings
   )
 
-lazy val root = (project in file(".")).dependsOn(util)
+lazy val root = (project in file("."))
+  .aggregate(util)
+  .dependsOn(util)
   .settings(
     commonSettings
   )

--- a/extras/build.sbt
+++ b/extras/build.sbt
@@ -1,5 +1,1 @@
 name := "circe-examples-extra"
-
-// Macro paradise
-resolvers += Resolver.sonatypeRepo("releases")
-addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)

--- a/extras/src/main/scala/CirceEnumVariant.scala
+++ b/extras/src/main/scala/CirceEnumVariant.scala
@@ -1,7 +1,6 @@
 package circeeg.extras
 
 import scala.annotation.StaticAnnotation
-import scala.annotation.compileTimeOnly
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox
 

--- a/extras/src/main/scala/CirceEnumVariant.scala
+++ b/extras/src/main/scala/CirceEnumVariant.scala
@@ -4,10 +4,13 @@ import scala.annotation.StaticAnnotation
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox
 
+import com.github.ghik.silencer.silent
+
 class CirceEnumVariant extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro CirceEnumVariantMacro.impl
 }
 
+@silent
 private class CirceEnumVariantMacro(val c: whitebox.Context) {
   import c.universe._
 
@@ -47,7 +50,7 @@ private class CirceEnumVariantMacro(val c: whitebox.Context) {
     val invocationTree = targetCtorSym.typeSignature match {
       case NullaryMethodType(_) => q"$target.$targetCtorSym"  // Non-parentheses method
       case _ =>
-        val flattenedParams = targetCtorSym.paramss.flatMap(_.map(target => Ident(target.name)))
+        val flattenedParams = targetCtorSym.paramLists.flatMap(_.map(target => Ident(target.name)))
         q"new $classTypeName($innerCaseClass(..$flattenedParams))"
     }
 

--- a/extras/src/main/scala/CirceEnumVariant.scala
+++ b/extras/src/main/scala/CirceEnumVariant.scala
@@ -4,13 +4,10 @@ import scala.annotation.StaticAnnotation
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox
 
-import com.github.ghik.silencer.silent
-
 class CirceEnumVariant extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro CirceEnumVariantMacro.impl
 }
 
-@silent
 private class CirceEnumVariantMacro(val c: whitebox.Context) {
   import c.universe._
 
@@ -59,7 +56,7 @@ private class CirceEnumVariantMacro(val c: whitebox.Context) {
 
   def impl(annottees: Tree*): Tree = {
     annottees match {
-      case (clsDef @ q"$mods class $tpname(..$paramss) extends { ..$earlydefns } with ..$parents { $self => ..$stats }") :: _ if paramss.length == 1 => {
+      case (clsDef @ q"$_ class $tpname(..$paramss) extends { ..$_ } with ..$_ { $_ => ..$_ }") :: _ if paramss.length == 1 => {
         val classTypeName = tpname
         val classTermName = classTypeName.toTermName
         val classTypeStr = classTypeName.decodedName.toString

--- a/extras/src/main/scala/CirceForward.scala
+++ b/extras/src/main/scala/CirceForward.scala
@@ -1,7 +1,6 @@
 package circeeg.extras
 
 import scala.annotation.StaticAnnotation
-import scala.annotation.compileTimeOnly
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox
 

--- a/extras/src/main/scala/CirceForward.scala
+++ b/extras/src/main/scala/CirceForward.scala
@@ -4,10 +4,13 @@ import scala.annotation.StaticAnnotation
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox
 
+import com.github.ghik.silencer.silent
+
 class CirceForward extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro CirceForwardMacro.impl
 }
 
+@silent
 private class CirceForwardMacro(val c: whitebox.Context) {
   import c.universe._
 

--- a/extras/src/main/scala/CirceForward.scala
+++ b/extras/src/main/scala/CirceForward.scala
@@ -4,19 +4,16 @@ import scala.annotation.StaticAnnotation
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox
 
-import com.github.ghik.silencer.silent
-
 class CirceForward extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro CirceForwardMacro.impl
 }
 
-@silent
 private class CirceForwardMacro(val c: whitebox.Context) {
   import c.universe._
 
   def impl(annottees: Tree*): Tree = {
     annottees match {
-      case (clsDef @ q"case class $className(..$fields) extends { ..$earlydefns } with ..$parents { $self => ..$stats }") :: _ if fields.length == 1 => {
+      case (clsDef @ q"case class $className(..$fields) extends { ..$_ } with ..$_ { $_ => ..$_ }") :: _ if fields.length == 1 => {
         val classTypeName = className
         val classTermName = classTypeName.toTermName
         val classTypeStr = classTypeName.decodedName.toString

--- a/extras/src/main/scala/Delegate.scala
+++ b/extras/src/main/scala/Delegate.scala
@@ -2,10 +2,10 @@ package circeeg.extras
 
 import scala.annotation.StaticAnnotation
 import scala.language.experimental.macros
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 
 class delegate extends StaticAnnotation {
-  def macroTransform(annottees: Any*) = macro delegateMacro.impl
+  def macroTransform(annottees: Any*): Any = macro delegateMacro.impl
 }
 
 object delegateMacro {
@@ -68,9 +68,9 @@ object delegateMacro {
       } yield {
         val methodSymbol = methodToAdd.asMethod
 
-        val vparamss = methodSymbol.paramss.map(_.map {
+        val vparamss = methodSymbol.paramLists.map(_.map {
           paramSymbol => ValDef(
-            Modifiers(Flag.PARAM, tpnme.EMPTY, List()),
+            Modifiers(Flag.PARAM, typeNames.EMPTY, List()),
             paramSymbol.name.toTermName,
             TypeTree(paramSymbol.typeSignature),
             EmptyTree)
@@ -81,7 +81,7 @@ object delegateMacro {
           case _ =>
             Apply(
               Select(Ident(valDef.name), methodSymbol.name),
-              methodSymbol.paramss.flatMap(_.map(param => Ident(param.name)))) // TODO - multi params list
+              methodSymbol.paramLists.flatMap(_.map(param => Ident(param.name)))) // TODO - multi params list
         } 
 
         val methodDef = DefDef(Modifiers(),

--- a/extras/src/main/scala/Delegate.scala
+++ b/extras/src/main/scala/Delegate.scala
@@ -16,11 +16,7 @@ object delegateMacro {
       c.error(c.enclosingPosition, "This annotation can only be used on vals")
     }
 
-    def changeFirstTypeNameToTermName(t: Tree): Tree =
-      t match {
-        case tq"$base.$child" => q"$base.${child.toTermName}"
-        case tq"$child" => q"${TermName(child.toString)}"
-      }
+    
 
     def typeCheckExpressionOfType(typeTree: Tree): Type = {
       c.typecheck(tree = typeTree, mode = c.TYPEmode).tpe

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.15")

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,22 +1,22 @@
 package circeeg.main
 
-import cats.data.NonEmptyList
-import io.circe.Json
-import io.circe.parser.decode
-// This is for .asJson, usually imported as io.circe.syntax._
-import io.circe.syntax.EncoderOps
-import io.circe.Printer
 import java.time.{Duration, ZonedDateTime}
 
-import circeeg.util.{Base, B0, B1, B2}
-import circeeg.util.{Filter, DwellTimeFilter}
-import circeeg.util.{AgeBand, Demo, Gender}
+import cats.data.NonEmptyList
+import io.circe.Json
+import io.circe.Printer
+import io.circe.parser.decode
+import io.circe.syntax.EncoderOps
+
 import circeeg.util.EmptyMapAsNone
 import circeeg.util.Expr2
 import circeeg.util.ExprEnum
 import circeeg.util.NoneDefault._
 import circeeg.util.Sorl
 import circeeg.util.Untagged2
+import circeeg.util.{AgeBand, Demo, Gender}
+import circeeg.util.{Base, B0, B1, B2}
+import circeeg.util.{Filter, DwellTimeFilter}
 
 object Main extends App {
   val np = Printer.spaces2

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -9,10 +9,8 @@ import io.circe.Printer
 import java.time.{Duration, ZonedDateTime}
 
 import circeeg.util.{Base, B0, B1, B2}
-import circeeg.util.{FooVal, BarVal, Other}
 import circeeg.util.{Filter, DwellTimeFilter}
 import circeeg.util.{AgeBand, Demo, Gender}
-import circeeg.util.Conf.custom
 import circeeg.util.EmptyMapAsNone
 import circeeg.util.Expr2
 import circeeg.util.ExprEnum
@@ -201,12 +199,12 @@ object Main extends App {
   val c: Base = Base.C(NonEmptyList.one(123))
   val d: Base = Base.D()  // Variant with no fields works too
 
-  val encodedRandom = np.pretty(random.asJson)
+  val encodedRandom = np.print(random.asJson)
   val decodedRandom = decode[B0](encodedRandom).right.get
   pp("random-encode", encodedRandom)
   pp("random-decode", decodedRandom)
 
-  val encodedX = np.pretty(x.asJson)
+  val encodedX = np.print(x.asJson)
   val decodedX = decode[Base](encodedX).right.get
   pp("x-encode", encodedX)
   pp("x-decode", decodedX)
@@ -214,7 +212,7 @@ object Main extends App {
   pp("x-foo(0)", decodedX.foo(0))
   pp("x-id", decodedX.id)
 
-  val encodedY = np.pretty(y.asJson)
+  val encodedY = np.print(y.asJson)
   val decodedY = decode[Base](encodedY).right.get
   pp("y-encode", encodedY)
   pp("y-decode", decodedY)
@@ -222,7 +220,7 @@ object Main extends App {
   pp("y-foo(0)", decodedY.foo(0))
   pp("y-id", decodedY.id)
 
-  val encodedZ = np.pretty(z.asJson)
+  val encodedZ = np.print(z.asJson)
   val decodedZ = decode[Base](encodedZ).right.get
   pp("z-encode", encodedZ)
   pp("z-decode", decodedZ)
@@ -230,7 +228,7 @@ object Main extends App {
   pp("z-foo(0)", decodedZ.foo(0))
   pp("z-id", decodedZ.id)
 
-  val encodedA = np.pretty(a.asJson)
+  val encodedA = np.print(a.asJson)
   val decodedA = decode[Base](encodedA).right.get
   pp("a-encode", encodedA)
   pp("a-decode", decodedA)
@@ -238,7 +236,7 @@ object Main extends App {
   pp("a-foo(0)", decodedA.foo(0))
   pp("a-id", decodedA.id)
 
-  val encodedE = np.pretty(e.asJson)
+  val encodedE = np.print(e.asJson)
   val decodedE = decode[Base](encodedE).right.get
   pp("empty-encode", encodedE)
   pp("empty-decode", decodedE)
@@ -246,7 +244,7 @@ object Main extends App {
   pp("empty-foo(0)", decodedE.foo(0))
   pp("empty-id", decodedE.id)
 
-  val encodedB = np.pretty(b.asJson)
+  val encodedB = np.print(b.asJson)
   val decodedB = decode[Base](encodedB).right.get
   pp("b-encode", encodedB)
   pp("b-decode", decodedB)
@@ -254,7 +252,7 @@ object Main extends App {
   pp("b-foo(0)", decodedB.foo(0))
   pp("b-id", decodedB.id)
 
-  val encodedC = np.pretty(c.asJson)
+  val encodedC = np.print(c.asJson)
   val decodedC = decode[Base](encodedC).right.get
   pp("c-encode", encodedC)
   pp("c-decode", decodedC)
@@ -262,7 +260,7 @@ object Main extends App {
   pp("c-foo(0)", decodedC.foo(0))
   pp("c-id", decodedC.id)
 
-  val encodedD = np.pretty(d.asJson)
+  val encodedD = np.print(d.asJson)
   val decodedD = decode[Base](encodedD).right.get
   pp("d-encode", encodedD)
   pp("d-decode", decodedD)
@@ -286,10 +284,10 @@ object Main extends App {
   )
 
   // dwellTimeFilter.asJson.spaces2 also works
-  pp("encodedDwellTimeFilterWithNull", np.pretty(dwellTimeFilter.asJson))
-  pp("encodedDwellTimeFilterWithoutNull", dnp.pretty(dwellTimeFilter.asJson))
-  pp("decodedDwellTimeFilterWithNull", decode[Filter](np.pretty(dwellTimeFilter.asJson)).right.get)
-  pp("decodedDwellTimeFilterWithoutNull", decode[Filter](dnp.pretty(dwellTimeFilter.asJson)).right.get)
+  pp("encodedDwellTimeFilterWithNull", np.print(dwellTimeFilter.asJson))
+  pp("encodedDwellTimeFilterWithoutNull", dnp.print(dwellTimeFilter.asJson))
+  pp("decodedDwellTimeFilterWithNull", decode[Filter](np.print(dwellTimeFilter.asJson)).right.get)
+  pp("decodedDwellTimeFilterWithoutNull", decode[Filter](dnp.print(dwellTimeFilter.asJson)).right.get)
 
   //
   // Demo
@@ -340,19 +338,19 @@ object Main extends App {
   // Demo
 
   val demo1 = Demo(ages = None, genders = None)
-  pp("encodedDemo1WithNull", np.pretty(demo1.asJson))
-  pp("encodedDemo1WithoutNull", dnp.pretty(demo1.asJson))
-  pp("decodedDemo1WithNull", decode[Demo](np.pretty(demo1.asJson)).right.get)
-  pp("decodedDemo1WithoutNull", decode[Demo](dnp.pretty(demo1.asJson)).right.get)
+  pp("encodedDemo1WithNull", np.print(demo1.asJson))
+  pp("encodedDemo1WithoutNull", dnp.print(demo1.asJson))
+  pp("decodedDemo1WithNull", decode[Demo](np.print(demo1.asJson)).right.get)
+  pp("decodedDemo1WithoutNull", decode[Demo](dnp.print(demo1.asJson)).right.get)
 
   val demo2 = Demo(
     ages = Some(Set(AgeBand.withName("40-44"), AgeBand.withName("45-49"))),
     genders = Some(Set(Gender.withName("male"), Gender.withName("female")))
   )
-  pp("encodedDemo2WithNull", np.pretty(demo2.asJson))
-  pp("encodedDemo2WithoutNull", dnp.pretty(demo2.asJson))
-  pp("decodedDemo2WithNull", decode[Demo](np.pretty(demo2.asJson)).right.get)
-  pp("decodedDemo2WithoutNull", decode[Demo](dnp.pretty(demo2.asJson)).right.get)
+  pp("encodedDemo2WithNull", np.print(demo2.asJson))
+  pp("encodedDemo2WithoutNull", dnp.print(demo2.asJson))
+  pp("decodedDemo2WithNull", decode[Demo](np.print(demo2.asJson)).right.get)
+  pp("decodedDemo2WithoutNull", decode[Demo](dnp.print(demo2.asJson)).right.get)
 
   //
   // Others

--- a/util/build.sbt
+++ b/util/build.sbt
@@ -1,5 +1,1 @@
 name := "circe-examples-util"
-
-// Macro paradise
-resolvers += Resolver.sonatypeRepo("releases")
-addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)

--- a/util/src/main/scala/Base.scala
+++ b/util/src/main/scala/Base.scala
@@ -1,10 +1,9 @@
 package circeeg.util
 
 import cats.data.NonEmptyList
-import cats.syntax.either._
 import io.circe.generic.extras.ConfiguredJsonCodec
 
-import circeeg.extras.{CirceEnumVariant, delegate}
+import circeeg.extras.CirceEnumVariant
 import circeeg.util.Conf.custom
 
 // Scala has a fairly cheat way to "union" the ADT variants if the variants

--- a/util/src/main/scala/Demo.scala
+++ b/util/src/main/scala/Demo.scala
@@ -1,7 +1,7 @@
 package circeeg.util
 
-import io.circe.generic.extras.ConfiguredJsonCodec
 import enumeratum._
+import io.circe.generic.extras.ConfiguredJsonCodec
 
 import circeeg.util.Conf.custom
 

--- a/util/src/main/scala/EmptyMapAsNone.scala
+++ b/util/src/main/scala/EmptyMapAsNone.scala
@@ -1,12 +1,11 @@
 package circeeg.util
 
 import io.circe.{Decoder, Encoder, HCursor, Json}
-import scala.util.{Left, Right}
+import scala.util.Right
 
 case class EmptyMapAsNone[A](val toOption: Option[A])
 
 object EmptyMapAsNone {
-  import cats.syntax.either._
   import io.circe.syntax._
 
   final def apply[A](x: A): EmptyMapAsNone[A] = EmptyMapAsNone[A](Option(x))

--- a/util/src/main/scala/EmptyMapAsNone.scala
+++ b/util/src/main/scala/EmptyMapAsNone.scala
@@ -1,7 +1,8 @@
 package circeeg.util
 
-import io.circe.{Decoder, Encoder, HCursor, Json}
 import scala.util.Right
+
+import io.circe.{Decoder, Encoder, HCursor, Json}
 
 case class EmptyMapAsNone[A](val toOption: Option[A])
 

--- a/util/src/main/scala/Expr.scala
+++ b/util/src/main/scala/Expr.scala
@@ -2,7 +2,7 @@ package circeeg.util
 
 import io.circe.generic.extras.ConfiguredJsonCodec
 
-import circeeg.extras.{CirceForward, CirceEnumVariant, delegate}
+import circeeg.extras.{CirceForward, CirceEnumVariant}
 import circeeg.util.Conf.custom
 
 trait Expr {

--- a/util/src/main/scala/Expr2.scala
+++ b/util/src/main/scala/Expr2.scala
@@ -2,7 +2,7 @@ package circeeg.util
 
 import io.circe.generic.extras.ConfiguredJsonCodec
 
-import circeeg.extras.{CirceForward, CirceEnumVariant, delegate}
+import circeeg.extras.CirceEnumVariant
 import circeeg.util.Conf.custom
 
 @ConfiguredJsonCodec

--- a/util/src/main/scala/Expr2Impl.scala
+++ b/util/src/main/scala/Expr2Impl.scala
@@ -1,8 +1,6 @@
 package circeeg.util
 
-import io.circe.generic.extras.ConfiguredJsonCodec
 
-import circeeg.util.Conf.custom
 
 trait Expr2Impl {
   def eval: Int

--- a/util/src/main/scala/Filter.scala
+++ b/util/src/main/scala/Filter.scala
@@ -1,6 +1,5 @@
 package circeeg.util
 
-import io.circe.generic.JsonCodec
 import io.circe.generic.extras.ConfiguredJsonCodec
 import java.time.{Duration, ZonedDateTime}
 

--- a/util/src/main/scala/Filter.scala
+++ b/util/src/main/scala/Filter.scala
@@ -1,7 +1,8 @@
 package circeeg.util
 
-import io.circe.generic.extras.ConfiguredJsonCodec
 import java.time.{Duration, ZonedDateTime}
+
+import io.circe.generic.extras.ConfiguredJsonCodec
 
 import circeeg.util.Conf.custom
 

--- a/util/src/main/scala/SingleOrList.scala
+++ b/util/src/main/scala/SingleOrList.scala
@@ -1,12 +1,10 @@
 package circeeg.util
 
 import io.circe.{Decoder, Encoder, HCursor, Json}
-import scala.util.{Left, Right}
 
 case class Sorl[T](val toList: List[T])
 
 object Sorl {
-  import cats.syntax.either._
   import io.circe.syntax._
 
   final def apply[T](vs: T*): Sorl[T] = Sorl[T](List(vs: _*))

--- a/util/src/main/scala/Untagged.scala
+++ b/util/src/main/scala/Untagged.scala
@@ -23,7 +23,6 @@ class Untagged2[T1, T2] private {
 }
 
 object Untagged2 {
-  import cats.syntax.either._
   import io.circe.syntax._
 
   sealed trait Variant[T1, T2]


### PR DESCRIPTION
Able to remove unused stuff for all projects.

Fix `build.sbt` by using both `aggregate` and `dependsOn`. The former is
the one recursively passing down any sbt command to the subprojects.

Commonize the paradise compiler plugin into the root build.sbt.